### PR TITLE
Add `sh()` method for executing bash commands

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -5,7 +5,12 @@ var gulp = require('gulp')
   ,browserSync = require('browser-sync')
   ,reload = browserSync.reload
   ,sass = require('gulp-sass')
-  ,exec = require('gulp-exec');
+  ,exec = require('gulp-exec')
+  ,execSync = require('child_process').execSync;
+
+function sh(cmd) {
+  console.log(execSync(cmd, {encoding: 'utf8'}));
+}
 
 gulp.task('default', function() {
 


### PR DESCRIPTION
It's synchronous, so no callbacks or weird stuff to deal with. Also sends results of commands (`stdout`) right where it should be (visible to user in Terminal) via `console.log()`.